### PR TITLE
fix: initialized response value in get_instance_in_group

### DIFF
--- a/src/spaceone/inventory/connector/google_cloud_compute_connector.py
+++ b/src/spaceone/inventory/connector/google_cloud_compute_connector.py
@@ -57,13 +57,11 @@ class GoogleCloudComputeConnector(BaseConnector):
 
         while request is not None:
             response = request.execute()
-            _LOGGER.debug(f'[list_instances] response => {response}')
             for key, _instance_list in response['items'].items():
                 if 'instances' in _instance_list:
                     instance_list.extend(_instance_list.get('instances'))
             request = self.client.instances().aggregatedList_next(previous_request=request,
                                                                   previous_response=response)
-        _LOGGER.debug(f'[list_instances] instance_list => {instance_list}')
         return instance_list
 
     def list_machine_types(self, **query):
@@ -72,7 +70,6 @@ class GoogleCloudComputeConnector(BaseConnector):
         request = self.client.machineTypes().aggregatedList(**query)
         while request is not None:
             response = request.execute()
-            _LOGGER.debug(f'[list_machine_types] response => {response}')
             for key, machine_type in response['items'].items():
                 if 'machineTypes' in machine_type:
                     machine_type_list.extend(machine_type.get('machineTypes'))
@@ -88,7 +85,6 @@ class GoogleCloudComputeConnector(BaseConnector):
 
         while request is not None:
             response = request.execute()
-            _LOGGER.debug(f'[list_url_maps] response => {response}')
             for key, url_scoped_list in response['items'].items():
                 if 'urlMaps' in url_scoped_list:
                     url_map_list.extend(url_scoped_list.get('urlMaps'))
@@ -102,7 +98,6 @@ class GoogleCloudComputeConnector(BaseConnector):
         request = self.client.backendServices().aggregatedList(**query)
         while request is not None:
             response = request.execute()
-            _LOGGER.debug(f'[list_back_end_services] response => {response}')
             for key, url_scoped_list in response['items'].items():
                 if 'backendServices' in url_scoped_list:
                     backend_svc_list.extend(url_scoped_list.get('backendServices'))
@@ -117,7 +112,6 @@ class GoogleCloudComputeConnector(BaseConnector):
         request = self.client.disks().aggregatedList(**query)
         while request is not None:
             response = request.execute()
-            _LOGGER.debug(f'[list_disks] response => {response}')
             for key, _disk in response['items'].items():
                 if 'disks' in _disk:
                     disk_list.extend(_disk.get('disks'))
@@ -132,7 +126,6 @@ class GoogleCloudComputeConnector(BaseConnector):
         request = self.client.autoscalers().aggregatedList(**query)
         while request is not None:
             response = request.execute()
-            _LOGGER.debug(f'[list_autoscalers] response => {response}')
             for key, _autoscaler_list in response['items'].items():
                 if 'autoscalers' in _autoscaler_list:
                     autoscaler_list.extend(_autoscaler_list.get('autoscalers'))
@@ -148,7 +141,6 @@ class GoogleCloudComputeConnector(BaseConnector):
 
         while request is not None:
             response = request.execute()
-            _LOGGER.debug(f'[list_firewall] response => {response}')
             for backend_bucket in response.get('items', []):
                 firewalls_list.append(backend_bucket)
             request = self.client.firewalls().list_next(previous_request=request, previous_response=response)
@@ -175,9 +167,7 @@ class GoogleCloudComputeConnector(BaseConnector):
                           'orderBy': 'creationTimestamp desc'}
                          )
             response = self.client.images().list(**query).execute()
-            _LOGGER.debug(f'[list_images] response => {response}')
             public_images[public_image.get('key')] = response.get('items', [])
-            _LOGGER.debug(f'[list_images] public_images => {public_images}')
 
         return public_images
 
@@ -210,7 +200,6 @@ class GoogleCloudComputeConnector(BaseConnector):
         request = self.client.instanceGroups().listInstances(**query).execute() if key == 'zone' else \
             self.client.regionInstanceGroups().listInstances(**query).execute()
         response = request.get('items', [])
-        _LOGGER.debug(f'[list_instance_from_instance_groups] response => {response}')
 
         return response
 
@@ -221,7 +210,6 @@ class GoogleCloudComputeConnector(BaseConnector):
 
         while request is not None:
             response = request.execute()
-            _LOGGER.debug(f'[list_instance_group_managers] response => {response}')
             for key, _instance_group_manager_list in response['items'].items():
                 if 'instanceGroupManagers' in _instance_group_manager_list:
                     instance_group_manager_list.extend(_instance_group_manager_list.get('instanceGroupManagers'))
@@ -236,7 +224,6 @@ class GoogleCloudComputeConnector(BaseConnector):
         request = self.client.networks().list(**query)
         while request is not None:
             response = request.execute()
-            _LOGGER.debug(f'[list_vpcs] response => {response}')
             for network in response.get('items', []):
                 network_list.append(network)
             request = self.client.networks().list_next(previous_request=request, previous_response=response)
@@ -249,7 +236,6 @@ class GoogleCloudComputeConnector(BaseConnector):
         request = self.client.subnetworks().aggregatedList(**query)
         while request is not None:
             response = request.execute()
-            _LOGGER.debug(f'[list_subnetworks] response => {response}')
             for name, _sbworks_list in response['items'].items():
                 if 'subnetworks' in _sbworks_list:
                     subnetworks_list.extend(_sbworks_list.get('subnetworks'))
@@ -265,7 +251,6 @@ class GoogleCloudComputeConnector(BaseConnector):
 
         while request is not None:
             response = request.execute()
-            _LOGGER.debug(f'[list_target_pools] response => {response}')
             for key, pool_scoped_list in response['items'].items():
                 if 'targetPools' in pool_scoped_list:
                     target_pool_list.extend(pool_scoped_list.get('targetPools'))
@@ -280,7 +265,6 @@ class GoogleCloudComputeConnector(BaseConnector):
         request = self.client.forwardingRules().aggregatedList(**query)
         while request is not None:
             response = request.execute()
-            _LOGGER.debug(f'[list_forwarding_rules] response => {response}')
             for key, forwarding_scoped_list in response['items'].items():
                 if 'forwardingRules' in forwarding_scoped_list:
                     forwarding_rule_list.extend(forwarding_scoped_list.get('forwardingRules'))
@@ -289,7 +273,6 @@ class GoogleCloudComputeConnector(BaseConnector):
         return forwarding_rule_list
 
     def set_instance_into_instance_group_managers(self, instance_group_managers):
-        _LOGGER.debug(f'[set_instance_into_instance_group_managers] Start')
         for instance_group in instance_group_managers:
             key, loc = self._get_loc_from(instance_group)
             instance_group_name = instance_group.get('name', '')
@@ -300,9 +283,15 @@ class GoogleCloudComputeConnector(BaseConnector):
 
     def get_instance_in_group(self, key, value, instance_group, **query):
         query.update({'project': self.project_id, key: value, 'instanceGroup': instance_group})
+        _LOGGER.debug(f'[get_instance_in_group] query => {query}')
         response = self.client.instanceGroups().listInstances(**query).execute() if key == 'zone' else \
             self.client.regionInstanceGroups().listInstances(**query).execute()
-
+        # NoneType error occurs sometimes. To prevent them insert default value.
+        if response is None:
+            _LOGGER.debug(f'[get_instance_in_group] response is None')
+            response = {'items': []}
+        else:
+            _LOGGER.debug(f'[get_instance_in_group] response => {response}')
         return response
 
     def _get_filter_to_params(self, **query):

--- a/src/spaceone/inventory/manager/collector_manager.py
+++ b/src/spaceone/inventory/manager/collector_manager.py
@@ -116,7 +116,6 @@ class CollectorManager(BaseManager):
 
             val = _self_link[_self_link.find('/zones/') + 7:] if 'zones' in self_link \
                 else _self_link[_self_link.find('/regions/') + 9:]
-            _LOGGER.debug(f'[get_global_resources] val => {val}')
 
             instances = self.gcp_connector.get_instance_in_group('zone', val,
                                                                  instance_group_name) if 'zones' in self_link else \


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
- Updated response in get_instance_in_group connector code
- This will prevent NoneType error 
- Traceback log
- 
`2021-12-23T05:14:48.163Z [ERROR] tnx-662270d9a7e1 Collector.collect (collector_service.py:154) [list_resources] get collected_region => 'NoneType' object is not iterable
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/plugin_googlecloud_compute-1.3.5-py3.8.egg/spaceone/inventory/service/collector_service.py", line 140, in list_resources
    compute_vm_resources = self.collector_manager.list_resources(params)
  File "/usr/local/lib/python3.8/site-packages/plugin_googlecloud_compute-1.3.5-py3.8.egg/spaceone/inventory/manager/collector_manager.py", line 68, in list_resources
    global_resources = self.get_global_resources(secret_data)
  File "/usr/local/lib/python3.8/site-packages/plugin_googlecloud_compute-1.3.5-py3.8.egg/spaceone/inventory/manager/collector_manager.py", line 125, in get_global_resources
    instance_groups_instance.extend(instances.get('items'))
TypeError: 'NoneType' object is not iterable
`

### Known issue