### PR TITLE
fix: Nonetype error, fire_wall_target_tag referenced before assignment.

### DIFF
--- a/src/spaceone/inventory/manager/compute_engine/security_group_manager.py
+++ b/src/spaceone/inventory/manager/compute_engine/security_group_manager.py
@@ -48,8 +48,7 @@ class SecurityGroupManager(BaseManager):
 
             elif "targetServiceAccounts" in firewall:
                 for firewall_target_service_account in firewall.get('targetServiceAccounts', []):
-                    if firewall_target_service_account in inst_svc_accounts or \
-                            'allow-all-instance' in fire_wall_target_tag:
+                    if firewall_target_service_account in inst_svc_accounts:
                         protocol_ports_list = self.get_allowed_or_denied_info(firewall)
                         self.append_security_group(protocol_ports_list, firewall, sg_rules)
 

--- a/src/spaceone/inventory/manager/compute_engine/vpc_manager.py
+++ b/src/spaceone/inventory/manager/compute_engine/vpc_manager.py
@@ -29,8 +29,11 @@ class VPCManager(BaseManager):
 
         vpc_data = {}
         subnet_data = {}
+        matched_vpc = None
+
         matched_subnet = self._get_matching_subnet(instance, subnets)
-        matched_vpc = self.get_matching_vpc(matched_subnet, vpcs)
+        if matched_subnet is not None:
+            matched_vpc = self.get_matching_vpc(matched_subnet, vpcs)
 
         if matched_vpc is not None:
             vpc_data.update({


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
- Error Message: "NoneType object has no attribute get" Error
```
  File "/usr/local/lib/python3.8/site-packages/plugin_googlecloud_compute-1.3.7-py3.8.egg/spaceone/inventory/manager/compute_engine/vpc_manager.py", line 57, in get_matching_vpc
    network = matched_subnet.get('selfLink', None)
AttributeError: 'NoneType' object has no attribute 'get'
```
- "local variable fire_wall_target_tag referenced before assignment" Error
```
  File "/usr/local/lib/python3.8/site-packages/plugin_googlecloud_compute-1.3.7-py3.8.egg/spaceone/inventory/manager/compute_engine/security_group_manager.py", line 52, in get_security_group_rules_info
    'allow-all-instance' in fire_wall_target_tag:
UnboundLocalError: local variable 'fire_wall_target_tag' referenced before assignment
```
### Known issue