### PR TITLE
fix: NoneType return error in subnetworks

### DIFF
--- a/src/spaceone/inventory/manager/collector_manager.py
+++ b/src/spaceone/inventory/manager/collector_manager.py
@@ -100,17 +100,13 @@ class CollectorManager(BaseManager):
             self.set_connector(secret_data)
 
         instance_groups_instance = []
-        _LOGGER.debug(f'[get_global_resources] List Instance Group Managers')
         instance_group = self.gcp_connector.list_instance_group_managers()
-        _LOGGER.debug(f'[get_global_resources] instance_group => {instance_group}')
-        _LOGGER.debug(f'[get_global_resources] Set Instance Into Instance Group Managers')
         self.gcp_connector.set_instance_into_instance_group_managers(instance_group)
 
         managed_state_less = [i.get('selfLink') for i in instance_group if
                               i.get('status', {}).get('stateful', {}).get('hasStatefulConfig') == False]
-        _LOGGER.debug(f'[get_global_resources] managed_state_less => {managed_state_less}')
+
         for self_link in managed_state_less:
-            _LOGGER.debug(f'[get_global_resources] self_link => {self_link}')
             _self_link = self_link[:self_link.find('/instanceGroupManagers/')]
             instance_group_name = self_link[self_link.rfind('/')+1:]
 
@@ -120,7 +116,6 @@ class CollectorManager(BaseManager):
             instances = self.gcp_connector.get_instance_in_group('zone', val,
                                                                  instance_group_name) if 'zones' in self_link else \
                 self.gcp_connector.get_instance_in_group('region', val, instance_group_name)
-            _LOGGER.debug(f'[get_global_resources] instances => {instances}')
             # if instance created by instance group but stopped, instances has return value
             '''
             In some case, instance is exists in instance list but does not in instancegroup.

--- a/src/spaceone/inventory/manager/compute_engine/security_group_manager.py
+++ b/src/spaceone/inventory/manager/compute_engine/security_group_manager.py
@@ -44,7 +44,7 @@ class SecurityGroupManager(BaseManager):
                             or 'allow-all-instance' in fire_wall_target_tag:
                         protocol_ports_list = self.get_allowed_or_denied_info(firewall)
                         # skipping, seems to have bug protocol_ports_list => [{'protocol': ['all'], 'port': '0-65535'}]
-                        #self.append_security_group(protocol_ports_list, firewall, sg_rules)
+                        # self.append_security_group(protocol_ports_list, firewall, sg_rules)
 
             elif "targetServiceAccounts" in firewall:
                 for firewall_target_service_account in firewall.get('targetServiceAccounts', []):

--- a/src/spaceone/inventory/manager/compute_engine/vpc_manager.py
+++ b/src/spaceone/inventory/manager/compute_engine/vpc_manager.py
@@ -38,23 +38,21 @@ class VPCManager(BaseManager):
         matched_subnet = self._get_matching_subnet(instance, subnets)
         matched_vpc = self._get_matching_vpc(matched_subnet, vpcs)
 
-        if matched_vpc is not None:
-            vpc_data.update({
-                'vpc_id': matched_vpc.get('id', ''),
-                'vpc_name': matched_vpc.get('name', ''),
-                'description': matched_vpc.get('description', ''),
-                'self_link': matched_vpc.get('selfLink', ''),
-            })
+        vpc_data.update({
+            'vpc_id': matched_vpc.get('id', ''),
+            'vpc_name': matched_vpc.get('name', ''),
+            'description': matched_vpc.get('description', ''),
+            'self_link': matched_vpc.get('selfLink', ''),
+        })
 
-        if matched_subnet is not None:
-            subnet_data.update({
-                'subnet_id': matched_subnet.get('id', ''),
-                'cidr': matched_subnet.get('ipCidrRange', ''),
-                'subnet_name': matched_subnet.get('name', ''),
-                'gateway_address': matched_subnet.get('gatewayAddress', ''),
-                'vpc': vpc_data,
-                'self_link': matched_subnet.get('selfLink', '')
-            })
+        subnet_data.update({
+            'subnet_id': matched_subnet.get('id', ''),
+            'cidr': matched_subnet.get('ipCidrRange', ''),
+            'subnet_name': matched_subnet.get('name', ''),
+            'gateway_address': matched_subnet.get('gatewayAddress', ''),
+            'vpc': vpc_data,
+            'self_link': matched_subnet.get('selfLink', '')
+        })
 
         return VPC(vpc_data, strict=False), Subnet(subnet_data, strict=False)
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
- bugfix nonetype error in subnetworks

### Known issue
- If type of selfLink starts with '/xxx/xxx/xxx' subnet might not matched to instance
- This will improve in further releases